### PR TITLE
Fixed some i18n bugs

### DIFF
--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -260,7 +260,7 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
 
     # Reset fallbacks to fall back to our new default
     if ::I18n.respond_to?(:fallbacks)
-      ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new(@mount_at_root)
+      ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new(::I18n.default_locale)
     end
   end
 


### PR DESCRIPTION
- Helper methods were not getting the correct real paths from fully localized templates (e.g. `*.en.html.erb`). [middleman#2592](https://github.com/middleman/middleman/issues/2592)
- Fallback was not working with no mount config set. [middleman#2596](https://github.com/middleman/middleman/issues/2596)